### PR TITLE
Some compatibility updates

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -145,14 +145,15 @@ module RackDAV
         names = resource.property_names
       else
         names = request_match("/propfind/prop/*").map { |e| e.name }
-        names = resource.property_names
+        names = resource.property_names if names.empty?
         raise BadRequest if names.empty?
       end
 
       multistatus do |xml|
         for resource in find_resources
+          resource.path.gsub!(/\/\//, '/')
           xml.response do
-            xml.href "http://#{host}#{url_escape resource.path}"
+          	xml.href "http://#{host}#{url_escape resource.path}"
             propstats xml, get_properties(resource, names)
           end
         end

--- a/rack_dav.gemspec
+++ b/rack_dav.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'rack_dav'
-  s.version = '0.1.2'
+  s.version = '0.1.3'
   s.summary = 'WebDAV handler for Rack'
   s.author = 'Matthias Georgi'
   s.email = 'matti.georgi@gmail.com'


### PR DESCRIPTION
Hi georgi,

I made a few changes to rack_dav mainly because it wasn't working for me when I tried to access the WebDAV server from iWork on my iPad:
- Updated response header "DAV" with value "1,2" instead of just "2" since some server would check for class 1 before checking for class 2 (and "DAV: 2" actually fails litmus test as "DAV: 1,2" would pass)
- Updated response for PROPFIND with empty request body return all properties instead 400 400 since it's technically not invalid (still passes litmus test) and iWork on the iPad would actually make such request

Without Wax
Billy
