### PR TITLE
Fixed rack file "undefined method `begin' for nil:NilClass" bug.

### DIFF
--- a/lib/rack_dav/file_resource.rb
+++ b/lib/rack_dav/file_resource.rb
@@ -76,6 +76,7 @@ module RackDAV
       else
         file = Rack::File.new(nil)
         file.path = file_path
+        file.serving(request.env)
         response.body = file
       end
     end


### PR DESCRIPTION
When serving Rack::File, we need to prepare the file for reading
in chunks. Otherwise, the @range is not set and generates errors.
