### PR TITLE
Fix: multi-status res charset surrounded by quotes

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -343,7 +343,7 @@ module RackDAV
           yield xml
         end.to_xml
         response.body = [content]
-        response["Content-Type"] = 'text/xml; charset="utf-8"'
+        response["Content-Type"] = 'text/xml; charset=utf-8'
         response["Content-Length"] = Rack::Utils.bytesize(content).to_s
       end
 


### PR DESCRIPTION
The charset should not be surrounded by qoutes.
