### PR TITLE
Make it obvious which parameters must be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ to retrieve and change the resources:
 
 * __make\_collection__: Create this resource as collection.
 
-* __lock(token, timeout, scope, type, owner)__: Lock this resource.
+* __lock(locktoken, timeout, lockscope=nil, locktype=nil, owner=nil)__: Lock this resource.
   If scope, type and owner are nil, refresh the given lock.
 
 * __unlock(token)__: Unlock this resource


### PR DESCRIPTION
It took me a while to figure out why rack_dav wasn't working with my lockable resource, so I figured making it obvious that the lock method expects to be called with as few as 2 parameters would help others avoid spending time figuring it out for themselves.
