### PR TITLE
Moved the rack request and response objects to class variables on Resource

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -13,7 +13,7 @@ module RackDAV
       @request  = request
       @response = response
       @options  = options
-      @resource = resource_class.new(url_unescape(request.path_info), @options)
+      @resource = resource_class.new(url_unescape(request.path_info), @request, @response, @options)
       raise Forbidden if request.path_info.include?('../')
     end
 
@@ -52,20 +52,20 @@ module RackDAV
       response['Content-Length'] = resource.content_length.to_s
       response['Last-Modified'] = resource.last_modified.httpdate
       map_exceptions do
-        resource.get(request, response)
+        resource.get
       end
     end
 
     def put
       raise Forbidden if resource.collection?
       map_exceptions do
-        resource.put(request, response)
+        resource.put
       end
     end
 
     def post
       map_exceptions do
-        resource.post(request, response)
+        resource.post
       end
     end
 
@@ -97,7 +97,7 @@ module RackDAV
       raise BadGateway if dest_uri.host and dest_uri.host != request.host
       raise Forbidden if destination == resource.path
 
-      dest = resource_class.new(destination, @options)
+      dest = resource_class.new(destination, @request, @response, @options)
       dest = dest.child(resource.name) if dest.collection?
 
       dest_existed = dest.exist?
@@ -124,7 +124,7 @@ module RackDAV
       raise BadGateway if dest_uri.host and dest_uri.host != request.host
       raise Forbidden if destination == resource.path
 
-      dest = resource_class.new(destination, @options)
+      dest = resource_class.new(destination, @request, @response, @options)
       dest = dest.child(resource.name) if dest.collection?
 
       dest_existed = dest.exist?

--- a/lib/rack_dav/file_resource.rb
+++ b/lib/rack_dav/file_resource.rb
@@ -68,33 +68,33 @@ module RackDAV
     # HTTP GET request.
     #
     # Write the content of the resource to the response.body.
-    def get(request, response)
+    def get
       if stat.directory?
         content = ""
-        Rack::Directory.new(root).call(request.env)[2].each { |line| content << line }
-        response.body = [content]
-        response['Content-Length'] = (content.respond_to?(:bytesize) ? content.bytesize : content.size).to_s
+        Rack::Directory.new(root).call(@request.env)[2].each { |line| content << line }
+        @response.body = [content]
+        @response['Content-Length'] = (content.respond_to?(:bytesize) ? content.bytesize : content.size).to_s
       else
         file = File.open(file_path)
-        response.body = file
+        @response.body = file
       end
     end
 
     # HTTP PUT request.
     #
     # Save the content of the request.body.
-    def put(request, response)
-      if request.env['HTTP_CONTENT_MD5']
-        content_md5_pass?(request.env) or raise HTTPStatus::BadRequest.new('Content-MD5 mismatch')
+    def put
+      if @request.env['HTTP_CONTENT_MD5']
+        content_md5_pass?(@request.env) or raise HTTPStatus::BadRequest.new('Content-MD5 mismatch')
       end
 
-      write(request.body)
+      write(@request.body)
     end
 
     # HTTP POST request.
     #
     # Usually forbidden.
-    def post(request, response)
+    def post
       raise HTTPStatus::Forbidden
     end
 

--- a/lib/rack_dav/resource.rb
+++ b/lib/rack_dav/resource.rb
@@ -4,8 +4,10 @@ module RackDAV
 
     attr_reader :path, :options
 
-    def initialize(path, options)
+    def initialize(path, request, response, options)
       @path = path
+      @request = request
+      @response = response
       @options = options
     end
 
@@ -66,21 +68,21 @@ module RackDAV
     # HTTP GET request.
     #
     # Write the content of the resource to the response.body.
-    def get(request, response)
+    def get
       raise NotImplementedError
     end
 
     # HTTP PUT request.
     #
     # Save the content of the request.body.
-    def put(request, response)
+    def put
       raise NotImplementedError
     end
 
     # HTTP POST request.
     #
     # Usually forbidden.
-    def post(request, response)
+    def post
       raise NotImplementedError
     end
 
@@ -126,7 +128,7 @@ module RackDAV
     end
 
     def child(name, option={})
-      self.class.new(path + '/' + name, options)
+      self.class.new(path + '/' + name, @request, @response, options)
     end
 
     def lockable?


### PR DESCRIPTION
Moved the rack request and response objects to class variables on the Resource class so they are available to all methods in the Resource.

See: https://github.com/georgi/rack_dav/issues/22
