### PR TITLE
Fix LOCK crash on Nokogiri >= 1.6

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -296,8 +296,13 @@ module RackDAV
       end
 
       def request_document
-        @request_document ||= Nokogiri::XML(request.body.read) {|config| config.strict }
-      rescue Nokogiri::XML::SyntaxError
+        @request_document ||= if (body = request.body.read).empty?
+          Nokogiri::XML::Document.new
+        else
+          Nokogiri::XML(body, &:strict)
+        end
+
+      rescue Nokogiri::XML::SyntaxError, RuntimeError # Nokogiri raise RuntimeError :-(
         raise BadRequest
       end
 


### PR DESCRIPTION
Nokogiri >= 1.6 raises RuntimeError when given an empty string as document input with "strict" config, whilst 1.5 just returned an empty Nokogiri::XML::Document.

This patch also adds a broad rescue on RuntimeError, because Nokogiri raises that generic exception if it cannot parse the document. This should be better handled with Nokogiri maintainers.