### PR TITLE
MKCOL with body should return 415 Unsupported Media Type

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -83,6 +83,10 @@ module RackDAV
     end
 
     def mkcol
+      # Reject message bodies - RFC2518:8.3.1
+      body = @request.body.read(8)
+      fail UnsupportedMediaType if !body.nil? && body.length > 0
+
       map_exceptions do
         resource.make_collection
       end

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -364,6 +364,10 @@ describe RackDAV::Handler do
       multistatus_response('/d:propstat/d:prop/d:resourcetype/d:collection').should_not be_empty
     end
 
+    it 'should not create a collection with a body' do
+      mkcol('/folder', :input => 'body').should be_unsupported_media_type
+    end
+
     it 'should not find properties for nonexistent resources' do
       propfind('/non').should be_not_found
     end


### PR DESCRIPTION
This fixes the error on litmus basic test 14:

```
14. mkcol_with_body....... FAIL (MKCOL with weird body must fail (RFC2518:8.3.1))
```