### PR TITLE
MOVE onto existing collection should return 412 Precondition failed

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -130,8 +130,9 @@ module RackDAV
       raise Forbidden if destination == resource.path
 
       dest = resource_class.new(destination, @request, @response, @options)
-      dest = dest.child(resource.name) if dest.collection?
+      raise PreconditionFailed if dest.exist? && dest.collection? && !overwrite
 
+      dest = dest.child(resource.name) if dest.collection?
       dest_existed = dest.exist?
 
       raise Conflict if depth <= 1

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -358,6 +358,13 @@ describe RackDAV::Handler do
       get('/folder/b').should be_not_found
     end
 
+    it 'should not move a collection onto an existing collection without overwrite' do
+      mkcol('/folder').should be_created
+      mkcol('/dest').should be_created
+
+      move('/folder', 'HTTP_DESTINATION' => '/dest', 'HTTP_OVERWRITE' => 'F').should be_precondition_failed
+    end
+
     it 'should create a collection' do
       mkcol('/folder').should be_created
       propfind('/folder', :input => propfind_xml(:resourcetype))


### PR DESCRIPTION
This fixes litmus copymove test 10:

```
10. move_coll............. FAIL (MOVE-on-existing-coll should fail)
```