### PR TITLE
expect(collection).to have(1).part is deprecated

### DIFF
--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -78,7 +78,7 @@ describe RackDAV::Handler do
         it "sets a compliant rack response" do
           body = response.original_response.body
           body.should be_a(Array)
-          body.should have(1).part
+          expect(body.size).to eq(1)
         end
 
         it "prints the lockdiscovery" do


### PR DESCRIPTION
Fixes the deprecation warning from rspec:

```
`expect(collection).to have(1).part` is deprecated. Use the rspec-collection_matchers gem or replace your expectation with something like `expect(collection.size).to eq(1)` instead.
```