### PR TITLE
Copy w/out overwrite should return 412 Precondition Failed

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -103,6 +103,8 @@ module RackDAV
       raise Forbidden if destination == resource.path
 
       dest = resource_class.new(destination, @request, @response, @options)
+      raise PreconditionFailed if dest.exist? && !overwrite
+
       dest = dest.child(resource.name) if dest.collection?
 
       dest_existed = dest.exist?

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -308,10 +308,7 @@ describe RackDAV::Handler do
     it 'should deny a copy without overwrite' do
       put('/test', :input => 'body').should be_created
       put('/copy', :input => 'copy').should be_created
-      copy('/test', 'HTTP_DESTINATION' => '/copy', 'HTTP_OVERWRITE' => 'F')
-
-      multistatus_response('/d:href').first.text.should == 'http://localhost/test'
-      multistatus_response('/d:status').first.text.should match(/412 Precondition Failed/)
+      copy('/test', 'HTTP_DESTINATION' => '/copy', 'HTTP_OVERWRITE' => 'F').should be_precondition_failed
 
       get('/copy').body.should == 'copy'
     end


### PR DESCRIPTION
Fixes litmus copymove test 4:

```
4. copy_overwrite........ FAIL (COPY-on-existing with 'Overwrite: F' MUST fail with 412
(RFC4918:10.6): http://127.0.0.1:3000/litmus/copysrc: 412 Precondition Failed)
```