### PR TITLE
Move w/out overwrite should return 412 Precondition Failed

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -130,10 +130,10 @@ module RackDAV
       raise Forbidden if destination == resource.path
 
       dest = resource_class.new(destination, @request, @response, @options)
-      raise PreconditionFailed if dest.exist? && dest.collection? && !overwrite
+      raise PreconditionFailed if dest.exist? && !overwrite
 
-      dest = dest.child(resource.name) if dest.collection?
       dest_existed = dest.exist?
+      dest = dest.child(resource.name) if dest.collection?
 
       raise Conflict if depth <= 1
 

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -323,6 +323,12 @@ describe RackDAV::Handler do
       get('/copy').body.should == 'body'
     end
 
+    it 'should deny a move to an existing resource without overwrite' do
+      put('/test', :input => 'body').should be_created
+      put('/copy', :input => 'copy').should be_created
+      move('/test', 'HTTP_DESTINATION' => '/copy', 'HTTP_OVERWRITE' => 'F').should be_precondition_failed
+    end
+
     it 'should copy a collection' do
       mkcol('/folder').should be_created
       copy('/folder', 'HTTP_DESTINATION' => '/copy').should be_created


### PR DESCRIPTION
Fixes litmus copymove test 9 failure & warning:

```
9. move.................. FAIL (MOVE onto existing resource with 'Overwrite: F' MUST
fail with 412 (RFC4918:10.6): http://127.0.0.1:3000/litmus/move2: 412 Precondition Failed)
```
```
9. move.................. WARNING: MOVE to existing collection resource didn't give 204
```