### PR TITLE
Delete non-existent resource should return 404 Not Found

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -71,6 +71,8 @@ module RackDAV
     end
 
     def delete
+      raise NotFound if not resource.exist?
+
       delete_recursive(resource, errors = [])
 
       if errors.empty?

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -277,6 +277,10 @@ describe RackDAV::Handler do
       get('/folder/b').should be_not_found
     end
 
+    it 'should return not found when deleting a non-existent resource' do
+      delete('/not_found').should be_not_found
+    end
+
     it 'should not allow copy to another domain' do
       put('/test', :input => 'body').should be_created
       copy('http://localhost/', 'HTTP_DESTINATION' => 'http://another/').should be_bad_gateway


### PR DESCRIPTION
Fixes litmus copymove test 8:

```
 8. copy_shallow.......... FAIL (DELETE on `/litmus/foo' should fail with 404: got 0)
```