### PR TITLE
Add custom properties implementation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     rack_dav (0.4.0)
+      ffi-xattr (~> 0.1)
       nokogiri (~> 1.5)
       rack (~> 1.4)
 
@@ -9,11 +10,15 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    ffi (1.9.10)
+    ffi (1.9.10-java)
+    ffi-xattr (0.1.2)
+      ffi
     mini_portile (0.6.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     nokogiri (1.6.6.2-java)
-    rack (1.6.0)
+    rack (1.6.4)
     rake (0.9.6)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ script looks like this:
 
     require 'rubygems'
     require 'rack_dav'
-    
+
     use Rack::CommonLogger
-    
+
     run RackDAV::Handler.new(:root => '/path/to/docs')
 
 ## Implementing your own WebDAV resource
@@ -84,6 +84,10 @@ to retrieve and change the resources:
 * __move(dest)__: Move this resource to given destination resource.
 
 * __make\_collection__: Create this resource as collection.
+
+* __set_custom_property(name, value)__: Set a custom property on the resource. If the value is nil, delete the custom property.
+
+* __get_custom_property(name)__: Return the value of the named custom property.
 
 * __lock(locktoken, timeout, lockscope=nil, locktype=nil, owner=nil)__: Lock this resource.
   If scope, type and owner are nil, refresh the given lock.

--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -204,7 +204,7 @@ module RackDAV
       # </set></propertyupdate>
       nodes.each do |n|
         nd = n.namespace_definitions.first
-        if nd.prefix.nil? && nd.href.empty?
+        if !nd.nil? && nd.prefix.nil? && nd.href.empty?
           n.add_namespace(nil, '')
         end
       end

--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -194,15 +194,14 @@ module RackDAV
     def proppatch
       raise NotFound if not resource.exist?
 
-      prop_rem = request_match("/d:propertyupdate/d:remove/d:prop/*")
-      prop_set = request_match("/d:propertyupdate/d:set/d:prop/*")
+      nodes = request_match("/d:propertyupdate[d:remove/d:prop/* or d:set/d:prop/*]//d:prop/*")
 
       # Set a blank namespace if one is included in the request
       # See litmus props test 15
       # <propertyupdate xmlns="DAV:"><set>
       #   <prop><nonamespace xmlns="">randomvalue</nonamespace></prop>
       # </set></propertyupdate>
-      [prop_rem, prop_set].flatten.each do |n|
+      nodes.each do |n|
         nd = n.namespace_definitions.first
         if nd.prefix.nil? && nd.href.empty?
           n.add_namespace(nil, '')
@@ -213,8 +212,7 @@ module RackDAV
         for resource in find_resources
           xml.response do
             xml.href "http://#{host}#{resource.path}"
-            propstats xml, set_properties(resource, prop_set)
-            propstats xml, set_properties(resource, prop_rem)
+            propstats xml, set_properties(resource, nodes)
           end
         end
       end

--- a/lib/rack_dav/resource.rb
+++ b/lib/rack_dav/resource.rb
@@ -148,6 +148,7 @@ module RackDAV
       when 'getcontenttype'   then content_type
       when 'getetag'          then etag
       when 'getlastmodified'  then last_modified.httpdate
+      else self.get_custom_property(name) if self.respond_to?(:get_custom_property)
       end
     end
 
@@ -157,13 +158,14 @@ module RackDAV
       when 'getcontenttype'  then self.content_type = value
       when 'getetag'         then self.etag = value
       when 'getlastmodified' then self.last_modified = Time.httpdate(value)
+      else self.set_custom_property(name, value) if self.respond_to?(:set_custom_property)
       end
     rescue ArgumentError
       raise HTTPStatus::Conflict
     end
 
     def remove_property(name)
-      raise HTTPStatus::Forbidden
+      raise HTTPStatus::Forbidden if property_names.include?(name)
     end
 
     def parent

--- a/rack_dav.gemspec
+++ b/rack_dav.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("rack", "~> 1.4")
   s.add_dependency('nokogiri', "~> 1.5")
+  s.add_dependency("ffi-xattr", "~> 0.1")
   s.add_development_dependency("rspec", "~> 2.11")
   s.add_development_dependency("rake","~> 0.9")
 end

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -26,6 +26,12 @@ class Rack::MockResponse
 
 end
 
+if ENV['TRAVIS']
+  RSpec.configure do |c|
+    c.filter_run_excluding :has_xattr_support => true
+  end
+end
+
 describe RackDAV::Handler do
 
   DOC_ROOT = File.expand_path(File.dirname(__FILE__) + '/htdocs')
@@ -411,7 +417,7 @@ describe RackDAV::Handler do
       multistatus_response('/d:propstat/d:prop/d:getcontentlength').first.text.should == '7'
     end
 
-    it 'should set custom properties in the dav namespace' do
+    it 'should set custom properties in the dav namespace', :has_xattr_support => true do
       put('/prop', :input => 'A').should be_created
       proppatch('/prop', :input => propset_xml([:foo, 'testing']))
       multistatus_response('/d:propstat/d:prop/d:foo').should_not be_empty
@@ -420,7 +426,7 @@ describe RackDAV::Handler do
       multistatus_response('/d:propstat/d:prop/d:foo').first.text.should == 'testing'
     end
 
-    it 'should set custom properties in custom namespaces' do
+    it 'should set custom properties in custom namespaces', :has_xattr_support => true do
       xmlns = { 'xmlns:s' => 'SPEC:' }
       put('/prop', :input => 'A').should be_created
       proppatch('/prop', :input => propset_xml(['s:foo'.to_sym, 'testing', xmlns]))
@@ -430,7 +436,7 @@ describe RackDAV::Handler do
       multistatus_response('/d:propstat/d:prop/s:foo', xmlns).first.text.should == 'testing'
     end
 
-    it 'should copy custom properties' do
+    it 'should copy custom properties', :has_xattr_support => true do
       xmlns = { 'xmlns:s' => 'SPEC:' }
       put('/prop', :input => 'A').should be_created
       proppatch('/prop', :input => propset_xml(['s:foo'.to_sym, 'testing', xmlns]))

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -411,6 +411,44 @@ describe RackDAV::Handler do
       multistatus_response('/d:propstat/d:prop/d:getcontentlength').first.text.should == '7'
     end
 
+    it 'should set custom properties in the dav namespace' do
+      put('/prop', :input => 'A').should be_created
+      proppatch('/prop', :input => propset_xml([:foo, 'testing']))
+      multistatus_response('/d:propstat/d:prop/d:foo').should_not be_empty
+
+      propfind('/prop', :input => propfind_xml(:foo))
+      multistatus_response('/d:propstat/d:prop/d:foo').first.text.should == 'testing'
+    end
+
+    it 'should set custom properties in custom namespaces' do
+      xmlns = { 'xmlns:s' => 'SPEC:' }
+      put('/prop', :input => 'A').should be_created
+      proppatch('/prop', :input => propset_xml(['s:foo'.to_sym, 'testing', xmlns]))
+      multistatus_response('/d:propstat/d:prop/s:foo', xmlns).should_not be_empty
+
+      propfind('/prop', :input => propfind_xml(['s:foo'.to_sym, xmlns]))
+      multistatus_response('/d:propstat/d:prop/s:foo', xmlns).first.text.should == 'testing'
+    end
+
+    it 'should copy custom properties' do
+      xmlns = { 'xmlns:s' => 'SPEC:' }
+      put('/prop', :input => 'A').should be_created
+      proppatch('/prop', :input => propset_xml(['s:foo'.to_sym, 'testing', xmlns]))
+      multistatus_response('/d:propstat/d:prop/s:foo', xmlns).should_not be_empty
+
+      copy('/prop', 'HTTP_DESTINATION' => '/propcopy').should be_created
+      propfind('/propcopy', :input => propfind_xml(['s:foo'.to_sym, xmlns]))
+      multistatus_response('/d:propstat/d:prop/s:foo', xmlns).first.text.should == 'testing'
+    end
+
+    it 'should not set properties for a non-existent resource' do
+      proppatch('/not_found', :input => propset_xml([:foo, 'testing'])).should be_not_found
+    end
+
+    it 'should not return properties for non-existent resource' do
+      propfind('/prop', :input => propfind_xml(:foo)).should be_not_found
+    end
+
     it 'should return the correct charset (utf-8)' do
       put('/test.html', :input => '<html/>').should be_created
       propfind('/test.html', :input => propfind_xml(:getcontenttype, :getcontentlength))
@@ -495,22 +533,39 @@ describe RackDAV::Handler do
       match['/d:locktoken/d:href'].first.text.should == token
     end
 
-    def multistatus_response(pattern)
+    def multistatus_response(pattern, ns=nil)
+      xmlns = { 'd' => 'DAV:' }
+      xmlns.merge!(ns) unless ns.nil?
+
       @response.should be_multi_status
-      response_xml.xpath("/d:multistatus/d:response", 'd' => 'DAV:').should_not be_empty
-      response_xml.xpath("/d:multistatus/d:response" + pattern, 'd' => 'DAV:')
+      response_xml.xpath("/d:multistatus/d:response", xmlns).should_not be_empty
+      response_xml.xpath("/d:multistatus/d:response" + pattern, xmlns)
     end
 
     def propfind_xml(*props)
       render do |xml|
         xml.propfind('xmlns' => "DAV:") do
           xml.prop do
-            props.each do |prop|
-            xml.send prop.to_sym
+            props.each do |prop, attrs|
+              xml.send(prop.to_sym, attrs)
             end
           end
         end
       end
     end
 
+    def propset_xml(*props)
+      render do |xml|
+        xml.propertyupdate('xmlns' => 'DAV:') do
+          xml.set do
+            xml.prop do
+              props.each do |prop, value, attrs|
+                attrs = {} if attrs.nil?
+                xml.send(prop.to_sym, value, attrs)
+              end
+            end
+          end
+        end
+      end
+    end
 end

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -388,7 +388,7 @@ describe RackDAV::Handler do
 
     it 'should find all properties' do
       xml = render do |xml|
-        xml.propfind('xmlns:d' => "DAV:") do
+        xml.propfind('xmlns' => "DAV:") do
           xml.allprop
         end
       end
@@ -503,7 +503,7 @@ describe RackDAV::Handler do
 
     def propfind_xml(*props)
       render do |xml|
-        xml.propfind('xmlns:d' => "DAV:") do
+        xml.propfind('xmlns' => "DAV:") do
           xml.prop do
             props.each do |prop|
             xml.send prop.to_sym


### PR DESCRIPTION
To pass the Litmus `props` test suite, rack_dav has to be able to set and delete custom properties on resources. This PR adds API so that Resource implementations can support custom properties, and implements them in FileResource using extended attributes (by way of the [ffi-xattr gem](https://github.com/jarib/ffi-xattr)). The result fully passes all Litmus tests:

```
-> running `props':
 0. init.................. pass
 1. begin................. pass
 2. propfind_invalid...... pass
 3. propfind_invalid2..... pass
 4. propfind_d0........... pass
 5. propinit.............. pass
 6. propset............... pass
 7. propget............... pass
 8. propextended.......... pass
 9. propmove.............. pass
10. propget............... pass
11. propdeletes........... pass
12. propget............... pass
13. propreplace........... pass
14. propget............... pass
15. propnullns............ pass
16. propget............... pass
17. prophighunicode....... pass
18. propget............... pass
19. propremoveset......... pass
20. propget............... pass
21. propsetremove......... pass
22. propget............... pass
23. propvalnspace......... pass
24. propwformed........... pass
25. propinit.............. pass
26. propmanyns............ pass
27. propget............... pass
28. propcleanup........... pass
29. finish................ pass
<- summary for `props': of 30 tests run: 30 passed, 0 failed. 100.0%
```

Note that `get_custom_property` and `set_custom_property` are guarded with a `reponds_to?` check, so existing Resource classes should continue to work without changes.