### PR TITLE
Allow bare plus symbols to be used in URLs as spaces

### DIFF
--- a/lib/rack_dav/controller.rb
+++ b/lib/rack_dav/controller.rb
@@ -18,11 +18,11 @@ module RackDAV
     end
 
     def url_escape(s)
-      URI.escape(s)
+      ::URI.escape(s)
     end
 
     def url_unescape(s)
-      URI.unescape(s).force_valid_encoding
+      ::Rack::Utils.unescape(s).force_valid_encoding
     end
 
     def options


### PR DESCRIPTION
The main reason for doing this is that `Rack::Directory` (used for GET requests of directories) renders spaces in links in this way.  Without this patch, clicking a link from the `Rack::Directory` view to a file or a collection with a space in the name results in a 404.
